### PR TITLE
feature/dev6 changed status after invite

### DIFF
--- a/client/src/app/components/lobby/lobby.component.html
+++ b/client/src/app/components/lobby/lobby.component.html
@@ -38,7 +38,7 @@
           <span class="status-dot" [ngClass]="{
             'online': user.status === 'online',
             'in-game': user.status === 'in-game',
-            'challenging': user.status === 'challenging'
+            'invited': user.status === 'invited'
           }"></span>
           <span class="username" [title]="user.username">
             {{ user.username }}
@@ -48,7 +48,7 @@
           <button 
             class="action-button" 
             (click)="openUserMenu($event, user)" 
-            [disabled]="user.username === username || user.status !== 'online'"
+            [disabled]="user.username === username"
           >⋮</button>
         </div>
       </div>
@@ -93,14 +93,14 @@
     </div>
   </div>
   
-  <!-- Challenge Dialog -->
-  <div class="challenge-dialog" *ngIf="activeChallenge">
-    <div class="challenge-content">
-      <p><strong>{{ activeChallenge.challenger }}</strong> has challenged you to a game!</p>
-      <p>Time remaining: {{ activeChallenge.timeLeft }} seconds</p>
-      <div class="challenge-actions">
-        <button class="accept-btn" (click)="respondToChallenge('accept')">Accept</button>
-        <button class="decline-btn" (click)="respondToChallenge('decline')">Decline</button>
+  <!-- Invite Dialog -->
+  <div class="invite-dialog" *ngIf="activeInvite">
+    <div class="invite-content">
+      <p><strong>{{ activeInvite.inviter }}</strong> has invited you to a game!</p>
+      <p>Time remaining: {{ activeInvite.timeLeft }} seconds</p>
+      <div class="invite-actions">
+        <button class="accept-btn" (click)="respondToInvite('accept')">Accept</button>
+        <button class="decline-btn" (click)="respondToInvite('decline')">Decline</button>
       </div>
     </div>
   </div>

--- a/client/src/app/components/lobby/lobby.component.scss
+++ b/client/src/app/components/lobby/lobby.component.scss
@@ -140,6 +140,10 @@
       &.challenging {
         background-color: #f1c40f; /* Yellow color for challenging status */
       }
+
+      &.invited {
+        background-color: #f1c40f; /* Yellow color for invited status */
+      }
     }
     
     .username {
@@ -346,6 +350,65 @@
   }
   
   .challenge-actions {
+    display: flex;
+    justify-content: center;
+    gap: 15px;
+    margin-top: 20px;
+    
+    button {
+      padding: 8px 20px;
+      border: none;
+      border-radius: 4px;
+      cursor: pointer;
+      font-weight: bold;
+    }
+    
+    .accept-btn {
+      background-color: #2ecc71;
+      color: white;
+      
+      &:hover {
+        background-color: #27ae60;
+      }
+    }
+    
+    .decline-btn {
+      background-color: #e74c3c;
+      color: white;
+      
+      &:hover {
+        background-color: #c0392b;
+      }
+    }
+  }
+}
+
+.invite-dialog {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+  
+  .invite-content {
+    background-color: white;
+    padding: 20px;
+    border-radius: 8px;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+    width: 300px;
+    text-align: center;
+    
+    p {
+      margin: 10px 0;
+    }
+  }
+  
+  .invite-actions {
     display: flex;
     justify-content: center;
     gap: 15px;

--- a/server/game/consumers.py
+++ b/server/game/consumers.py
@@ -211,9 +211,9 @@ class GameConsumer(AsyncWebsocketConsumer):
                             'created_at': datetime.now().isoformat()
                         }
                         
-                        # Update user statuses
-                        self.connected_users[challenger]['status'] = 'in-game'
-                        self.connected_users[username]['status'] = 'in-game'
+                        # Update user statuses to 'invited' (yellow) instead of 'in-game'
+                        self.connected_users[challenger]['status'] = 'invited'
+                        self.connected_users[username]['status'] = 'invited'
                         
                         # Send updated user list
                         await self.update_user_list()


### PR DESCRIPTION
This pull request introduces a significant refactor to replace the concept of "challenges" with "invitations" in the lobby component of the application. The changes update both the frontend and backend to reflect this new terminology and behavior, including UI adjustments, logic updates, and status handling.

### Frontend Changes

#### UI and Status Updates:
* Replaced the "challenging" status with "invited" in the lobby UI, including updates to the status dot and user interaction rules. (`lobby.component.html` - [[1]](diffhunk://#diff-87c26bb810ba5c8fc14a9d048a10e517a61a456b4f6e2b277c480c0ddeb4a823L41-R41) [[2]](diffhunk://#diff-87c26bb810ba5c8fc14a9d048a10e517a61a456b4f6e2b277c480c0ddeb4a823L51-R51); `lobby.component.scss` - [[3]](diffhunk://#diff-25cc135754303efdebf911b495e8f3b7860953343482268c36fde48b53046962R143-R146)
* Updated the dialog for game invitations, replacing the challenge dialog with an invite dialog, and adjusted its styling and behavior. (`lobby.component.html` - [[1]](diffhunk://#diff-87c26bb810ba5c8fc14a9d048a10e517a61a456b4f6e2b277c480c0ddeb4a823L96-R103); `lobby.component.scss` - [[2]](diffhunk://#diff-25cc135754303efdebf911b495e8f3b7860953343482268c36fde48b53046962R386-R444)

#### Component Logic:
* Replaced all occurrences of "challenge" with "invite" in the `LobbyComponent`, including variables, methods, and event handling logic. (`lobby.component.ts` - [[1]](diffhunk://#diff-39cde7dea8a6e7b93018848f753b0caa3c65f3992ceed48ed17d18614fe5c8c1L36-R44) [[2]](diffhunk://#diff-39cde7dea8a6e7b93018848f753b0caa3c65f3992ceed48ed17d18614fe5c8c1L126-R141) [[3]](diffhunk://#diff-39cde7dea8a6e7b93018848f753b0caa3c65f3992ceed48ed17d18614fe5c8c1L200-R242) [[4]](diffhunk://#diff-39cde7dea8a6e7b93018848f753b0caa3c65f3992ceed48ed17d18614fe5c8c1R295-R411)
* Introduced new rules for inviting users based on their current status (e.g., "invited" players cannot invite others). (`lobby.component.ts` - [client/src/app/components/lobby/lobby.component.tsL200-R242](diffhunk://#diff-39cde7dea8a6e7b93018848f753b0caa3c65f3992ceed48ed17d18614fe5c8c1L200-R242))

### Backend Changes

* Updated the server logic to set user statuses to "invited" instead of "in-game" when an invitation is sent. (`game/consumers.py` - [server/game/consumers.pyL214-R216](diffhunk://#diff-58adb96a66c9eb68d8cc5c23a050622c7e43dead404e2bcd2d0f21eb78a5bce8L214-R216))